### PR TITLE
Paths and file management

### DIFF
--- a/retinal_rl/analysis/plot.py
+++ b/retinal_rl/analysis/plot.py
@@ -6,7 +6,6 @@ import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
 import seaborn as sns
-import torch
 from matplotlib import gridspec, patches
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
@@ -14,8 +13,6 @@ from matplotlib.lines import Line2D
 from matplotlib.patches import Circle, Wedge
 from matplotlib.ticker import MaxNLocator
 from numpy import fft
-from torch import Tensor
-from torchvision.utils import make_grid
 
 from retinal_rl.models.brain import Brain
 from retinal_rl.models.objective import ContextT, Objective
@@ -23,22 +20,18 @@ from retinal_rl.util import FloatArray
 
 
 def plot_transforms(
-    source_transforms: Dict[str, Dict[float, List[torch.Tensor]]],
-    noise_transforms: Dict[str, Dict[float, List[torch.Tensor]]],
+    source_transforms: Dict[str, Dict[float, List[FloatArray]]],
+    noise_transforms: Dict[str, Dict[float, List[FloatArray]]],
 ) -> Figure:
-    """Use the result of the transform_base_images function to plot the effects of source and noise transforms on images.
+    """Plot effects of source and noise transforms on images.
 
     Args:
-    ----
-    source_transforms: A dictionary of source transforms and their effects on images.
-    noise_transforms: A dictionary of noise transforms and their effects on images.
+        source_transforms: Dictionary of source transforms (numpy arrays)
+        noise_transforms: Dictionary of noise transforms (numpy arrays)
 
     Returns:
-    -------
-    Figure: A matplotlib Figure containing the plotted transforms.
-
+        Figure containing the plotted transforms
     """
-    # Determine the number of transforms and images
     num_source_transforms = len(source_transforms)
     num_noise_transforms = len(noise_transforms)
     num_transforms = num_source_transforms + num_noise_transforms
@@ -48,12 +41,31 @@ def plot_transforms(
         ]
     )
 
-    # Create a figure with subplots for each transform
     fig, axs = plt.subplots(num_transforms, 1, figsize=(20, 5 * num_transforms))
     if num_transforms == 1:
         axs = [axs]
 
     transform_index = 0
+
+    def make_image_grid(arrays: List[FloatArray], nrow: int) -> FloatArray:
+        """Create a grid of images from a list of numpy arrays."""
+        # Assuming arrays are [C, H, W]
+        n = len(arrays)
+        if not n:
+            return np.array([])
+
+        ncol = nrow
+        nrow = (n - 1) // ncol + 1
+
+        C, H, W = arrays[0].shape
+        grid = np.zeros((C, H * nrow, W * ncol))
+
+        for idx, array in enumerate(arrays):
+            i = idx // ncol
+            j = idx % ncol
+            grid[:, i * H : (i + 1) * H, j * W : (j + 1) * W] = array
+
+        return grid
 
     # Plot source transforms
     for transform_name, transform_data in source_transforms.items():
@@ -62,19 +74,20 @@ def plot_transforms(
 
         # Create a grid of images for each step
         images = [
-            make_grid(
-                torch.stack([img * 0.5 + 0.5 for img in transform_data[step]]),
+            make_image_grid(
+                [(img * 0.5 + 0.5) for img in transform_data[step]],
                 nrow=num_images,
             )
             for step in steps
         ]
-        grid = make_grid(images, nrow=len(steps))
+        grid = make_image_grid(images, nrow=len(steps))
 
-        # Display the grid
-        ax.imshow(grid.permute(1, 2, 0))
+        # Move channels last for imshow
+        grid_display = np.transpose(grid, (1, 2, 0))
+        ax.imshow(grid_display)
         ax.set_title(f"Source Transform: {transform_name}")
         ax.set_xticks(
-            [(i + 0.5) * grid.shape[2] / len(steps) for i in range(len(steps))]
+            [(i + 0.5) * grid_display.shape[1] / len(steps) for i in range(len(steps))]
         )
         ax.set_xticklabels([f"{step:.2f}" for step in steps])
         ax.set_yticks([])
@@ -88,19 +101,20 @@ def plot_transforms(
 
         # Create a grid of images for each step
         images = [
-            make_grid(
-                torch.stack([img * 0.5 + 0.5 for img in transform_data[step]]),
+            make_image_grid(
+                [(img * 0.5 + 0.5) for img in transform_data[step]],
                 nrow=num_images,
             )
             for step in steps
         ]
-        grid = make_grid(images, nrow=len(steps))
+        grid = make_image_grid(images, nrow=len(steps))
 
-        # Display the grid
-        ax.imshow(grid.permute(1, 2, 0))
+        # Move channels last for imshow
+        grid_display = np.transpose(grid, (1, 2, 0))
+        ax.imshow(grid_display)
         ax.set_title(f"Noise Transform: {transform_name}")
         ax.set_xticks(
-            [(i + 0.5) * grid.shape[2] / len(steps) for i in range(len(steps))]
+            [(i + 0.5) * grid_display.shape[1] / len(steps) for i in range(len(steps))]
         )
         ax.set_xticklabels([f"{step:.2f}" for step in steps])
         ax.set_yticks([])
@@ -237,16 +251,17 @@ def plot_brain_and_optimizers(brain: Brain, objective: Objective[ContextT]) -> F
     return fig
 
 
-def plot_receptive_field_sizes(results: Dict[str, Dict[str, FloatArray]]) -> Figure:
+def plot_receptive_field_sizes(
+    input_shape: Tuple[int, ...], layers: Dict[str, Dict[str, FloatArray]]
+) -> Figure:
     """Plot the receptive field sizes for each layer of the convolutional part of the network."""
     # Get visual field size from the input shape
-    input_shape = results["input"]["shape"]
     [_, height, width] = list(input_shape)
 
     # Calculate receptive field sizes for each layer
     rf_sizes: List[Tuple[int, int]] = []
     layer_names: List[str] = []
-    for name, layer_data in results.items():
+    for name, layer_data in layers.items():
         if name == "input":
             continue
         rf = layer_data["receptive_fields"]
@@ -357,22 +372,26 @@ def plot_histories(histories: Dict[str, List[float]]) -> Figure:
 
 
 def plot_channel_statistics(
-    layer_data: Dict[str, FloatArray], layer_name: str, channel: int
+    receptive_fields: FloatArray,
+    spectral: Dict[str, FloatArray],
+    histogram: Dict[str, FloatArray],
+    layer_name: str,
+    channel: int,
 ) -> Figure:
     """Plot receptive fields, pixel histograms, and autocorrelation plots for a single channel in a layer."""
     fig, axs = plt.subplots(2, 3, figsize=(20, 10))
     fig.suptitle(f"Layer: {layer_name}, Channel: {channel}", fontsize=16)
 
     # Receptive Fields
-    rf = layer_data["receptive_fields"][channel]
+    rf = receptive_fields[channel]
     _plot_receptive_fields(axs[0, 0], rf)
     axs[0, 0].set_title("Receptive Field")
     axs[0, 0].set_xlabel("X")
     axs[0, 0].set_ylabel("Y")
 
     # Pixel Histograms
-    hist = layer_data["pixel_histograms"][channel]
-    bin_edges = layer_data["histogram_bin_edges"]
+    hist = histogram["channel_histograms"][channel]
+    bin_edges = histogram["bin_edges"]
     axs[1, 0].bar(
         bin_edges[:-1],
         hist,
@@ -387,7 +406,7 @@ def plot_channel_statistics(
 
     # Autocorrelation plots
     # Plot average 2D autocorrelation and variance
-    autocorr = fft.fftshift(layer_data["mean_autocorr"][channel])
+    autocorr = fft.fftshift(spectral["mean_autocorr"][channel])
     h, w = autocorr.shape
     extent = [-w // 2, w // 2, -h // 2, h // 2]
     im = axs[0, 1].imshow(
@@ -399,7 +418,7 @@ def plot_channel_statistics(
     fig.colorbar(im, ax=axs[0, 1])
     _set_integer_ticks(axs[0, 1])
 
-    autocorr_sd = fft.fftshift(np.sqrt(layer_data["var_autocorr"][channel]))
+    autocorr_sd = fft.fftshift(np.sqrt(spectral["var_autocorr"][channel]))
     im = axs[0, 2].imshow(
         autocorr_sd, cmap="inferno", origin="lower", extent=extent, vmin=0
     )
@@ -411,7 +430,7 @@ def plot_channel_statistics(
 
     # Plot average 2D power spectrum
     log_power_spectrum = fft.fftshift(
-        np.log1p(layer_data["mean_power_spectrum"][channel])
+        np.log1p(spectral["mean_power_spectrum"][channel])
     )
     h, w = log_power_spectrum.shape
 
@@ -425,7 +444,7 @@ def plot_channel_statistics(
     _set_integer_ticks(axs[1, 1])
 
     log_power_spectrum_sd = fft.fftshift(
-        np.log1p(np.sqrt(layer_data["var_power_spectrum"][channel]))
+        np.log1p(np.sqrt(spectral["var_power_spectrum"][channel]))
     )
     im = axs[1, 2].imshow(
         log_power_spectrum_sd,
@@ -450,16 +469,15 @@ def _set_integer_ticks(ax: Axes):
     ax.yaxis.set_major_locator(MaxNLocator(integer=True))
 
 
-# Function to plot the original and reconstructed images
 def plot_reconstructions(
     normalization_mean: List[float],
     normalization_std: List[float],
-    train_sources: List[Tuple[Tensor, int]],
-    train_inputs: List[Tuple[Tensor, int]],
-    train_estimates: List[Tuple[Tensor, int]],
-    test_sources: List[Tuple[Tensor, int]],
-    test_inputs: List[Tuple[Tensor, int]],
-    test_estimates: List[Tuple[Tensor, int]],
+    train_sources: List[Tuple[FloatArray, int]],
+    train_inputs: List[Tuple[FloatArray, int]],
+    train_estimates: List[Tuple[FloatArray, int]],
+    test_sources: List[Tuple[FloatArray, int]],
+    test_inputs: List[Tuple[FloatArray, int]],
+    test_estimates: List[Tuple[FloatArray, int]],
     num_samples: int,
 ) -> Figure:
     """Plot original and reconstructed images for both training and test sets, including the classes."""
@@ -474,27 +492,28 @@ def plot_reconstructions(
         test_recon, test_pred = test_estimates[i]
 
         # Unnormalize the original images using the normalization lists
+        # Arrays are already [C, H, W], need to move channels to last dimension
         train_source = (
-            train_source.permute(1, 2, 0).numpy() * normalization_std
+            np.transpose(train_source, (1, 2, 0)) * normalization_std
             + normalization_mean
         )
         train_input = (
-            train_input.permute(1, 2, 0).numpy() * normalization_std
+            np.transpose(train_input, (1, 2, 0)) * normalization_std
             + normalization_mean
         )
         train_recon = (
-            train_recon.permute(1, 2, 0).numpy() * normalization_std
+            np.transpose(train_recon, (1, 2, 0)) * normalization_std
             + normalization_mean
         )
         test_source = (
-            test_source.permute(1, 2, 0).numpy() * normalization_std
+            np.transpose(test_source, (1, 2, 0)) * normalization_std
             + normalization_mean
         )
         test_input = (
-            test_input.permute(1, 2, 0).numpy() * normalization_std + normalization_mean
+            np.transpose(test_input, (1, 2, 0)) * normalization_std + normalization_mean
         )
         test_recon = (
-            test_recon.permute(1, 2, 0).numpy() * normalization_std + normalization_mean
+            np.transpose(test_recon, (1, 2, 0)) * normalization_std + normalization_mean
         )
 
         axes[0, i].imshow(np.clip(train_source, 0, 1))
@@ -522,7 +541,6 @@ def plot_reconstructions(
         axes[5, i].set_title(f"Pred: {test_pred}")
 
     # Set y-axis labels for each row
-
     fig.text(
         0.02,
         0.90,

--- a/retinal_rl/analysis/plot.py
+++ b/retinal_rl/analysis/plot.py
@@ -19,6 +19,27 @@ from retinal_rl.models.objective import ContextT, Objective
 from retinal_rl.util import FloatArray
 
 
+def make_image_grid(arrays: List[FloatArray], nrow: int) -> FloatArray:
+    """Create a grid of images from a list of numpy arrays."""
+    # Assuming arrays are [C, H, W]
+    n = len(arrays)
+    if not n:
+        return np.array([])
+
+    ncol = nrow
+    nrow = (n - 1) // ncol + 1
+
+    nchns, hght, wdth = arrays[0].shape
+    grid = np.zeros((nchns, hght * nrow, wdth * ncol))
+
+    for idx, array in enumerate(arrays):
+        i = idx // ncol
+        j = idx % ncol
+        grid[:, i * hght : (i + 1) * hght, j * wdth : (j + 1) * wdth] = array
+
+    return grid
+
+
 def plot_transforms(
     source_transforms: Dict[str, Dict[float, List[FloatArray]]],
     noise_transforms: Dict[str, Dict[float, List[FloatArray]]],
@@ -46,26 +67,6 @@ def plot_transforms(
         axs = [axs]
 
     transform_index = 0
-
-    def make_image_grid(arrays: List[FloatArray], nrow: int) -> FloatArray:
-        """Create a grid of images from a list of numpy arrays."""
-        # Assuming arrays are [C, H, W]
-        n = len(arrays)
-        if not n:
-            return np.array([])
-
-        ncol = nrow
-        nrow = (n - 1) // ncol + 1
-
-        nchns, hght, wdth = arrays[0].shape
-        grid = np.zeros((nchns, hght * nrow, wdth * ncol))
-
-        for idx, array in enumerate(arrays):
-            i = idx // ncol
-            j = idx % ncol
-            grid[:, i * hght : (i + 1) * hght, j * wdth : (j + 1) * wdth] = array
-
-        return grid
 
     # Plot source transforms
     for transform_name, transform_data in source_transforms.items():

--- a/retinal_rl/analysis/plot.py
+++ b/retinal_rl/analysis/plot.py
@@ -57,13 +57,13 @@ def plot_transforms(
         ncol = nrow
         nrow = (n - 1) // ncol + 1
 
-        C, H, W = arrays[0].shape
-        grid = np.zeros((C, H * nrow, W * ncol))
+        nchns, hght, wdth = arrays[0].shape
+        grid = np.zeros((nchns, hght * nrow, wdth * ncol))
 
         for idx, array in enumerate(arrays):
             i = idx // ncol
             j = idx % ncol
-            grid[:, i * H : (i + 1) * H, j * W : (j + 1) * W] = array
+            grid[:, i * hght : (i + 1) * hght, j * wdth : (j + 1) * wdth] = array
 
         return grid
 

--- a/retinal_rl/analysis/statistics.py
+++ b/retinal_rl/analysis/statistics.py
@@ -102,36 +102,30 @@ def transform_base_images(
         src, _ = base_dataset[np.random.randint(base_len)]
         images.append(src)
 
-    results = TransformStatistics(
+    resultss = TransformStatistics(
         source_transforms={},
         noise_transforms={},
     )
 
-    for transform in imageset.source_transforms:
-        if isinstance(transform, ContinuousTransform):
-            results.source_transforms[transform.name] = {}
-            trans_range: Tuple[float, float] = transform.trans_range
-            transform_steps = np.linspace(*trans_range, num_steps)
-            for step in transform_steps:
-                results.source_transforms[transform.name][step] = []
-                for img in images:
-                    results.source_transforms[transform.name][step].append(
-                        imageset.to_tensor(transform.transform(img, step)).cpu().numpy()
-                    )
+    for transforms, results in [
+        (imageset.source_transforms, resultss.source_transforms),
+        (imageset.noise_transforms, resultss.noise_transforms),
+    ]:
+        for transform in transforms:
+            if isinstance(transform, ContinuousTransform):
+                results[transform.name] = {}
+                trans_range: Tuple[float, float] = transform.trans_range
+                transform_steps = np.linspace(*trans_range, num_steps)
+                for step in transform_steps:
+                    results[transform.name][step] = []
+                    for img in images:
+                        results[transform.name][step].append(
+                            imageset.to_tensor(transform.transform(img, step))
+                            .cpu()
+                            .numpy()
+                        )
 
-    for transform in imageset.noise_transforms:
-        if isinstance(transform, ContinuousTransform):
-            results.noise_transforms[transform.name] = {}
-            trans_range: Tuple[float, float] = transform.trans_range
-            transform_steps = np.linspace(*trans_range, num_steps)
-            for step in transform_steps:
-                results.noise_transforms[transform.name][step] = []
-                for img in images:
-                    results.noise_transforms[transform.name][step].append(
-                        imageset.to_tensor(transform.transform(img, step)).cpu().numpy()
-                    )
-
-    return results
+    return resultss
 
 
 def reconstruct_images(

--- a/runner/frameworks/classification/analyze.py
+++ b/runner/frameworks/classification/analyze.py
@@ -105,8 +105,8 @@ def analyze(
     if epoch == 0:
         _perform_initialization_analysis(
             channel_analysis,
-            analyses_dir,
             use_wandb,
+            analyses_dir,
             plot_dir,
             checkpoint_plot_dir,
             run_dir,
@@ -128,6 +128,7 @@ def analyze(
 
     _perform_reconstruction_analysis(
         use_wandb,
+        analyses_dir,
         plot_dir,
         checkpoint_plot_dir,
         device,
@@ -152,8 +153,8 @@ def _plot_and_save_histories(plot_dir: Path, histories: Dict[str, List[float]]):
 
 def _perform_initialization_analysis(
     channel_analysis: bool,
-    analyses_dir: Path,
     use_wandb: bool,
+    analyses_dir: Path,
     plot_dir: Path,
     checkpoint_plot_dir: Path,
     run_dir: Path,
@@ -326,6 +327,7 @@ def _analyze_regular_layer(
 
 def _perform_reconstruction_analysis(
     use_wandb: bool,
+    analyses_dir: Path,
     plot_dir: Path,
     checkpoint_plot_dir: Path,
     device: torch.device,
@@ -348,7 +350,7 @@ def _perform_reconstruction_analysis(
             reconstruct_images(device, brain, decoder, train_set, test_set, 5)
         )
         # Save the reconstructions
-        rec_path = plot_dir / f"{decoder}_reconstructions_epoch_{epoch}.json"
+        rec_path = analyses_dir / f"{decoder}_reconstructions_epoch_{epoch}.json"
         with open(rec_path, "w") as f:
             json.dump(rec_dict, f, cls=NumpyEncoder)
 

--- a/runner/frameworks/classification/analyze.py
+++ b/runner/frameworks/classification/analyze.py
@@ -347,6 +347,11 @@ def _perform_reconstruction_analysis(
         rec_dict = asdict(
             reconstruct_images(device, brain, decoder, train_set, test_set, 5)
         )
+        # Save the reconstructions
+        rec_path = plot_dir / f"{decoder}_reconstructions_epoch_{epoch}.json"
+        with open(rec_path, "w") as f:
+            json.dump(rec_dict, f, cls=NumpyEncoder)
+
         recon_fig = plot_reconstructions(
             norm_means,
             norm_stds,

--- a/runner/frameworks/classification/analyze.py
+++ b/runner/frameworks/classification/analyze.py
@@ -2,6 +2,8 @@ import json
 import logging
 import os
 import shutil
+from dataclasses import asdict
+from pathlib import Path
 from typing import Any, Dict, List
 
 import matplotlib.pyplot as plt
@@ -21,6 +23,8 @@ from retinal_rl.analysis.plot import (
     plot_transforms,
 )
 from retinal_rl.analysis.statistics import (
+    CNNStatistics,
+    LayerStatistics,
     cnn_statistics,
     reconstruct_images,
     transform_base_images,
@@ -29,7 +33,9 @@ from retinal_rl.classification.imageset import Imageset
 from retinal_rl.models.brain import Brain
 from retinal_rl.models.loss import ReconstructionLoss
 from retinal_rl.models.objective import ContextT, Objective
-from retinal_rl.util import FloatArray
+
+### Infrastructure ###
+
 
 logger = logging.getLogger(__name__)
 
@@ -37,73 +43,15 @@ init_dir = "initialization_analysis"
 
 
 class NumpyEncoder(json.JSONEncoder):
-    def default(self, obj):
+    """JSON encoder that handles numpy arrays."""
+
+    def default(self, obj: Any) -> Any:
         if isinstance(obj, np.ndarray):
             return obj.tolist()
         return super().default(obj)
 
 
-def save_statistics(cfg: DictConfig, stats: Dict[str, Any], epoch: int) -> None:
-    """Save statistics to a JSON file in the plot directory."""
-    stats_dir = os.path.join(cfg.path.plot_dir, "statistics")
-    os.makedirs(stats_dir, exist_ok=True)
-
-    filename = os.path.join(stats_dir, f"epoch_{epoch}_stats.json")
-    with open(filename, "w") as f:
-        json.dump(stats, f, cls=NumpyEncoder)
-
-    if cfg.logging.use_wandb:
-        wandb.save(filename, base_path=cfg.path.plot_dir, policy="now")
-
-
-def collect_statistics(
-    cfg: DictConfig,
-    device: torch.device,
-    brain: Brain,
-    objective: Objective[ContextT],
-    train_set: Imageset,
-    test_set: Imageset,
-    epoch: int,
-) -> Dict[str, Any]:
-    """Collect all statistics without plotting."""
-    stats = {}
-
-    # Collect CNN statistics
-    cnn_stats = cnn_statistics(
-        device,
-        test_set,
-        brain,
-        cfg.logging.channel_analysis,
-        cfg.logging.plot_sample_size,
-    )
-    stats["cnn_analysis"] = cnn_stats
-
-    # Collect reconstruction statistics if applicable
-    reconstruction_decoders = [
-        loss.target_decoder
-        for loss in objective.losses
-        if isinstance(loss, ReconstructionLoss)
-    ]
-
-    if reconstruction_decoders:
-        rec_stats = {}
-        for decoder in reconstruction_decoders:
-            rec_dict = reconstruct_images(
-                device, brain, decoder, train_set, test_set, 5
-            )
-            rec_stats[str(decoder)] = rec_dict
-        stats["reconstruction_analysis"] = rec_stats
-
-    # If it's initialization epoch, collect additional stats
-    if epoch == 0:
-        # Save brain summary
-        stats["brain_summary"] = brain.scan()
-
-        # Save transform statistics
-        transforms = transform_base_images(train_set, num_steps=5, num_images=2)
-        stats["transforms"] = transforms
-
-    return stats
+### Analysis ###
 
 
 def analyze(
@@ -117,73 +65,170 @@ def analyze(
     epoch: int,
     copy_checkpoint: bool = False,
 ):
-    # First collect all statistics
-    stats = collect_statistics(
-        cfg, device, brain, objective, train_set, test_set, epoch
-    )
+    results_dir = Path(cfg.path.data_dir) / "analyses"
+    results_dir.mkdir(exist_ok=True)
 
-    # Save statistics to file
-    save_statistics(cfg, stats, epoch)
-
-    # Plot histories if not using wandb
     if not cfg.logging.use_wandb:
         _plot_and_save_histories(cfg, histories)
 
-    # Plot CNN analysis
-    cnn_analysis = stats["cnn_analysis"]
+    # Get CNN statistics and save them
+    cnn_stats = cnn_statistics(
+        device,
+        test_set,
+        brain,
+        cfg.logging.channel_analysis,
+        cfg.logging.plot_sample_size,
+    )
+
+    # Save CNN statistics
+    with open(results_dir / f"cnn_stats_epoch_{epoch}.json", "w") as f:
+        json.dump(asdict(cnn_stats), f, cls=NumpyEncoder)
 
     if epoch == 0:
-        _plot_initialization_analysis(cfg, brain, objective, train_set, cnn_analysis)
+        _perform_initialization_analysis(cfg, brain, objective, train_set, cnn_stats)
 
-    _plot_layers(cfg, cnn_analysis, epoch, copy_checkpoint)
+    _analyze_layers(cfg, cnn_stats, epoch, copy_checkpoint)
 
-    # Plot reconstruction analysis if available
-    if "reconstruction_analysis" in stats:
-        _plot_reconstruction_analysis(
-            cfg, train_set, stats["reconstruction_analysis"], epoch, copy_checkpoint
-        )
+    _perform_reconstruction_analysis(
+        cfg, device, brain, objective, train_set, test_set, epoch, copy_checkpoint
+    )
 
 
-def _plot_initialization_analysis(
+def _plot_and_save_histories(cfg: DictConfig, histories: Dict[str, List[float]]):
+    hist_fig = plot_histories(histories)
+    _save_figure(cfg, "", "histories", hist_fig)
+    plt.close(hist_fig)
+
+
+def _perform_initialization_analysis(
     cfg: DictConfig,
     brain: Brain,
     objective: Objective[ContextT],
     train_set: Imageset,
-    cnn_analysis: Dict[str, Dict[str, FloatArray]],
+    cnn_stats: CNNStatistics,
 ):
-    # Save brain summary to file
-    filepath = os.path.join(cfg.path.run_dir, "brain_summary.txt")
-    with open(filepath, "w") as f:
-        f.write(brain.scan())
+    summary = brain.scan()
+    filepath = Path(cfg.path.run_dir) / "brain_summary.txt"
+    filepath.write_text(summary)
 
     if cfg.logging.use_wandb:
-        wandb.save(filepath, base_path=cfg.path.run_dir, policy="now")
+        wandb.save(str(filepath), base_path=cfg.path.run_dir, policy="now")
 
-    # Plot various initialization analyses
-    rf_sizes_fig = plot_receptive_field_sizes(cnn_analysis)
+    # TODO: This is a bit of a hack, we should refactor this to get the relevant information out of  cnn_stats
+    rf_sizes_fig = plot_receptive_field_sizes(**asdict(cnn_stats))
     _process_figure(cfg, False, rf_sizes_fig, init_dir, "receptive_field_sizes", 0)
 
     graph_fig = plot_brain_and_optimizers(brain, objective)
     _process_figure(cfg, False, graph_fig, init_dir, "brain_graph", 0)
 
     transforms = transform_base_images(train_set, num_steps=5, num_images=2)
-    transforms_fig = plot_transforms(**transforms)
+    # Save transform statistics
+    transform_path = Path(cfg.path.run_dir) / "results" / "transforms.json"
+    with open(transform_path, "w") as f:
+        json.dump(asdict(transforms), f, cls=NumpyEncoder)
+
+    transforms_fig = plot_transforms(**asdict(transforms))
     _process_figure(cfg, False, transforms_fig, init_dir, "transforms", 0)
 
-    _plot_input_layer(cfg, cnn_analysis["input"], cfg.logging.channel_analysis)
+    _analyze_input_layer(cfg, cnn_stats.layers["input"], cfg.logging.channel_analysis)
 
 
-def _plot_reconstruction_analysis(
+def _analyze_layers(
     cfg: DictConfig,
-    train_set: Imageset,
-    rec_stats: Dict[str, Dict],
+    cnn_stats: CNNStatistics,
     epoch: int,
     copy_checkpoint: bool,
 ):
-    norm_means, norm_stds = train_set.normalization_stats
-    for decoder, rec_dict in rec_stats.items():
+    for layer_name, layer_data in cnn_stats.layers.items():
+        if layer_name != "input":
+            _analyze_regular_layer(
+                cfg,
+                layer_name,
+                layer_data,
+                epoch,
+                copy_checkpoint,
+                cfg.logging.channel_analysis,
+            )
+
+
+def _analyze_input_layer(
+    cfg: DictConfig,
+    layer_statistics: LayerStatistics,
+    channel_analysis: bool,
+):
+    layer_rfs = layer_receptive_field_plots(layer_statistics.receptive_fields)
+    _process_figure(cfg, False, layer_rfs, init_dir, "input_rfs", 0)
+
+    if channel_analysis:
+        layer_dict = asdict(layer_statistics)
+        num_channels = int(layer_dict.pop("num_channels"))
+        for channel in range(num_channels):
+            channel_fig = plot_channel_statistics(
+                **layer_dict, layer_name="input", channel=channel
+            )
+            _process_figure(
+                cfg, False, channel_fig, init_dir, f"input_channel_{channel}", 0
+            )
+
+
+def _analyze_regular_layer(
+    cfg: DictConfig,
+    layer_name: str,
+    layer_statistics: LayerStatistics,
+    epoch: int,
+    copy_checkpoint: bool,
+    channel_analysis: bool,
+):
+    layer_rfs = layer_receptive_field_plots(layer_statistics.receptive_fields)
+    _process_figure(
+        cfg, copy_checkpoint, layer_rfs, "receptive_fields", f"{layer_name}", epoch
+    )
+
+    if channel_analysis:
+        layer_dict = asdict(layer_statistics)
+        num_channels = int(layer_dict.pop("num_channels"))
+        for channel in range(num_channels):
+            channel_fig = plot_channel_statistics(
+                **layer_dict, layer_name=layer_name, channel=channel
+            )
+
+            _process_figure(
+                cfg,
+                copy_checkpoint,
+                channel_fig,
+                f"{layer_name}_layer_channel_analysis",
+                f"channel_{channel}",
+                epoch,
+            )
+
+
+def _perform_reconstruction_analysis(
+    cfg: DictConfig,
+    device: torch.device,
+    brain: Brain,
+    objective: Objective[ContextT],
+    train_set: Imageset,
+    test_set: Imageset,
+    epoch: int,
+    copy_checkpoint: bool,
+):
+    reconstruction_decoders = [
+        loss.target_decoder
+        for loss in objective.losses
+        if isinstance(loss, ReconstructionLoss)
+    ]
+
+    for decoder in reconstruction_decoders:
+        norm_means, norm_stds = train_set.normalization_stats
+        rec_dict = asdict(
+            reconstruct_images(device, brain, decoder, train_set, test_set, 5)
+        )
         recon_fig = plot_reconstructions(
-            norm_means, norm_stds, **rec_dict, num_samples=5
+            norm_means,
+            norm_stds,
+            *rec_dict["train"].values(),
+            *rec_dict["test"].values(),
+            num_samples=5,
         )
         _process_figure(
             cfg,
@@ -195,73 +240,7 @@ def _plot_reconstruction_analysis(
         )
 
 
-# Rest of the helper functions remain the same
-def _plot_and_save_histories(cfg: DictConfig, histories: Dict[str, List[float]]):
-    hist_fig = plot_histories(histories)
-    _save_figure(cfg, "", "histories", hist_fig)
-    plt.close(hist_fig)
-
-
-def _plot_layers(
-    cfg: DictConfig,
-    cnn_analysis: Dict[str, Dict[str, FloatArray]],
-    epoch: int,
-    copy_checkpoint: bool,
-):
-    for layer_name, layer_data in cnn_analysis.items():
-        if layer_name != "input":
-            _plot_regular_layer(
-                cfg,
-                layer_name,
-                layer_data,
-                epoch,
-                copy_checkpoint,
-                cfg.logging.channel_analysis,
-            )
-
-
-def _plot_input_layer(
-    cfg: DictConfig,
-    layer_data: Dict[str, FloatArray],
-    channel_analysis: bool,
-):
-    layer_rfs = layer_receptive_field_plots(layer_data["receptive_fields"])
-    _process_figure(cfg, False, layer_rfs, init_dir, "input_rfs", 0)
-
-    if channel_analysis:
-        num_channels = int(layer_data["num_channels"])
-        for channel in range(num_channels):
-            channel_fig = plot_channel_statistics(layer_data, "input", channel)
-            _process_figure(
-                cfg, False, channel_fig, init_dir, f"input_channel_{channel}", 0
-            )
-
-
-def _plot_regular_layer(
-    cfg: DictConfig,
-    layer_name: str,
-    layer_data: Dict[str, FloatArray],
-    epoch: int,
-    copy_checkpoint: bool,
-    channel_analysis: bool,
-):
-    layer_rfs = layer_receptive_field_plots(layer_data["receptive_fields"])
-    _process_figure(
-        cfg, copy_checkpoint, layer_rfs, "receptive_fields", f"{layer_name}", epoch
-    )
-
-    if channel_analysis:
-        num_channels = int(layer_data["num_channels"])
-        for channel in range(num_channels):
-            channel_fig = plot_channel_statistics(layer_data, layer_name, channel)
-            _process_figure(
-                cfg,
-                copy_checkpoint,
-                channel_fig,
-                f"{layer_name}_layer_channel_analysis",
-                f"channel_{channel}",
-                epoch,
-            )
+### Helper Functions ###
 
 
 def _save_figure(cfg: DictConfig, sub_dir: str, file_name: str, fig: Figure) -> None:
@@ -282,13 +261,18 @@ def _checkpoint_copy(cfg: DictConfig, sub_dir: str, file_name: str, epoch: int) 
 
 
 def _wandb_title(title: str) -> str:
+    # Split the title by slashes
     parts = title.split("/")
 
     def capitalize_part(part: str) -> str:
+        # Split the part by dashes
         words = part.split("_")
+        # Capitalize each word
         capitalized_words = [word.capitalize() for word in words]
+        # Join the words with spaces
         return " ".join(capitalized_words)
 
+    # Capitalize each part, then join with slashes
     capitalized_parts = [capitalize_part(part) for part in parts]
     return "/".join(capitalized_parts)
 

--- a/runner/frameworks/classification/initialize.py
+++ b/runner/frameworks/classification/initialize.py
@@ -2,7 +2,9 @@
 ### Imports ###
 
 import logging
-import os
+from dataclasses import dataclass
+from os import getenv
+from pathlib import Path
 from typing import Any, Dict, List, Tuple, cast
 
 import omegaconf
@@ -15,68 +17,112 @@ from torch.optim.optimizer import Optimizer
 from retinal_rl.models.brain import Brain
 from runner.util import save_checkpoint
 
+### Infrastructure ###
+
+
 # Initialize the logger
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class InitConfig:
+    """Configuration for initialization."""
+
+    # Paths
+    data_dir: Path
+    checkpoint_dir: Path
+    plot_dir: Path
+    wandb_dir: Path
+
+    # WandB settings
+    use_wandb: bool
+    wandb_project: str
+    wandb_entity: str | None
+    wandb_preempt: bool
+
+    # Run settings
+    run_name: str
+    max_checkpoints: int
+
+    @classmethod
+    def from_dict_config(cls, cfg: DictConfig) -> "InitConfig":
+        """Create InitConfig from a DictConfig."""
+        return cls(
+            data_dir=Path(cfg.path.data_dir),
+            checkpoint_dir=Path(cfg.path.checkpoint_dir),
+            plot_dir=Path(cfg.path.plot_dir),
+            wandb_dir=Path(cfg.path.wandb_dir),
+            use_wandb=cfg.logging.use_wandb,
+            wandb_project=cfg.logging.wandb_project,
+            wandb_entity=None
+            if cfg.logging.wandb_entity == "default"
+            else cfg.logging.wandb_entity,
+            wandb_preempt=cfg.logging.wandb_preempt,
+            run_name=cfg.run_name,
+            max_checkpoints=cfg.logging.max_checkpoints,
+        )
+
+
+### Initialization ###
+
+
 def initialize(
-    cfg: DictConfig,
+    dict_cfg: DictConfig,
     brain: Brain,
     optimizer: Optimizer,
 ) -> Tuple[Brain, Optimizer, Dict[str, List[float]], int]:
     """Initialize the Brain, Optimizers, and training histories. Checks whether the experiment directory exists and loads the model and history if it does. Otherwise, initializes a new model and history."""
-    wandb_sweep_id = os.getenv("WANDB_SWEEP_ID", "local")
+
+    cfg = InitConfig.from_dict_config(dict_cfg)
+    wandb_sweep_id = getenv("WANDB_SWEEP_ID", "local")
     logger.info(f"Run Name: {cfg.run_name}")
     logger.info(f"(WANDB) Sweep ID: {wandb_sweep_id}")
 
     # If continuing from a previous run, load the model and history
-    if os.path.exists(cfg.path.data_dir):
+    if cfg.data_dir.exists():
         return _initialize_reload(cfg, brain, optimizer)
     # else, initialize a new model and history
+    logger.info(
+        f"Experiment data path {cfg.data_dir} does not exist. Initializing {cfg.run_name}."
+    )
     return _initialize_create(cfg, brain, optimizer)
 
 
 def _initialize_create(
-    cfg: DictConfig,
+    cfg: InitConfig,
     brain: Brain,
     optimizer: Optimizer,
 ) -> Tuple[Brain, Optimizer, Dict[str, List[float]], int]:
     epoch = 0
-    logger.info(
-        f"Experiment path {cfg.path.run_dir} does not exist. Initializing {cfg.run_name}."
-    )
-
     # initialize the training histories
     histories: Dict[str, List[float]] = {}
 
-    # create the directories
-    os.makedirs(cfg.path.data_dir)
-    os.makedirs(cfg.path.checkpoint_dir)
-    if not cfg.logging.use_wandb:
-        os.makedirs(cfg.path.plot_dir)
-
+    cfg.data_dir.mkdir(parents=True, exist_ok=True)
+    cfg.checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    if not cfg.use_wandb:
+        cfg.plot_dir.mkdir(parents=True, exist_ok=True)
     else:
-        os.makedirs(cfg.path.wandb_dir)
+        cfg.wandb_dir.mkdir(parents=True, exist_ok=True)
         # convert DictConfig to dict
         dict_conf = omegaconf.OmegaConf.to_container(
             cfg, resolve=True, throw_on_missing=True
         )
         dict_conf = cast(Dict[str, Any], dict_conf)
-        entity = cfg.logging.wandb_entity
+        entity = cfg.wandb_entity
         if entity == "default":
             entity = None
         wandb.init(
-            project=cfg.logging.wandb_project,
+            project=cfg.wandb_project,
             entity=entity,
             group=HydraConfig.get().runtime.choices.experiment,
             job_type=HydraConfig.get().runtime.choices.brain,
             config=dict_conf,
             name=cfg.run_name,
             id=cfg.run_name,
-            dir=cfg.path.wandb_dir,
+            dir=cfg.wandb_dir,
         )
 
-        if cfg.logging.wandb_preempt:
+        if cfg.wandb_preempt:
             wandb.mark_preempting()
 
         wandb.define_metric("Epoch")
@@ -84,9 +130,9 @@ def _initialize_create(
         wandb.define_metric("Test/*", step_metric="Epoch")
 
     save_checkpoint(
-        cfg.path.data_dir,
-        cfg.path.checkpoint_dir,
-        cfg.logging.max_checkpoints,
+        cfg.data_dir,
+        cfg.checkpoint_dir,
+        cfg.max_checkpoints,
         brain,
         optimizer,
         histories,
@@ -97,15 +143,15 @@ def _initialize_create(
 
 
 def _initialize_reload(
-    cfg: DictConfig, brain: Brain, optimizer: Optimizer
+    cfg: InitConfig, brain: Brain, optimizer: Optimizer
 ) -> Tuple[Brain, Optimizer, Dict[str, List[float]], int]:
     logger.info(
-        f"Experiment dir {cfg.path.run_dir} exists. Loading existing model and history."
+        f"Experiment data dir {cfg.data_dir} exists. Loading existing model and history."
     )
-    checkpoint_file = os.path.join(cfg.path.data_dir, "current_checkpoint.pt")
+    checkpoint_file = cfg.data_dir / "current_checkpoint.pt"
 
     # check if files don't exist
-    if not os.path.exists(checkpoint_file):
+    if not checkpoint_file.exists():
         logger.error(f"File not found: {checkpoint_file}")
         raise FileNotFoundError("Checkpoint file does not exist.")
 
@@ -115,22 +161,22 @@ def _initialize_reload(
     optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
     completed_epochs = checkpoint["completed_epochs"]
     history = checkpoint["histories"]
-    entity = cfg.logging.wandb_entity
+    entity = cfg.wandb_entity
     if entity == "default":
         entity = None
 
-    if cfg.logging.use_wandb:
+    if cfg.use_wandb:
         wandb.init(
-            project=cfg.logging.wandb_project,
+            project=cfg.wandb_project,
             entity=entity,
             group=HydraConfig.get().runtime.choices.experiment,
             job_type=HydraConfig.get().runtime.choices.brain,
             name=cfg.run_name,
             id=cfg.run_name,
             resume="must",
-            dir=cfg.path.wandb_dir,
+            dir=cfg.wandb_dir,
         )
-        if cfg.logging.wandb_preempt:
+        if cfg.wandb_preempt:
             wandb.mark_preempting()
 
     return brain, optimizer, history, completed_epochs

--- a/runner/util.py
+++ b/runner/util.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import shutil
+from pathlib import Path
 from typing import Any, Dict, List, Tuple, cast
 
 import networkx as nx
@@ -25,8 +26,8 @@ log = logging.getLogger(__name__)
 
 
 def save_checkpoint(
-    data_dir: str,
-    checkpoint_dir: str,
+    data_dir: Path,
+    checkpoint_dir: Path,
     max_checkpoints: int,
     brain: nn.Module,
     optimizer: Optimizer,
@@ -34,8 +35,8 @@ def save_checkpoint(
     completed_epochs: int,
 ) -> None:
     """Save a checkpoint of the model and optimizer state."""
-    current_file = os.path.join(data_dir, "current_checkpoint.pt")
-    checkpoint_file = os.path.join(checkpoint_dir, f"epoch_{completed_epochs}.pt")
+    current_file = data_dir / "current_checkpoint.pt"
+    checkpoint_file = checkpoint_dir / f"epoch_{completed_epochs}.pt"
     checkpoint_dict: Dict[str, Any] = {
         "completed_epochs": completed_epochs,
         "brain_state_dict": brain.state_dict(),
@@ -59,11 +60,10 @@ def save_checkpoint(
         os.remove(os.path.join(checkpoint_dir, checkpoints.pop()))
 
 
-def delete_results(cfg: DictConfig) -> None:
+def delete_results(run_dir: Path) -> None:
     """Delete the results directory."""
-    run_dir: str = cfg.path.run_dir
 
-    if not os.path.exists(run_dir):
+    if not run_dir.exists():
         print(f"Directory {run_dir} does not exist.")
         return
 


### PR DESCRIPTION
So this does quite a fair bit of refactoring.

- I setup the analyses in `statistics.py` to return dataclass instances to make things more manageable and readable. 
- I also made a push to a more pathlib style of directory management, in particular in the runner submodules.
- Generally going for a style where the at the top of the framework command (e.g. intialize, analyze or train) all necessary variables are extracted out of the DictConfig.
- Saving analysis results to disk was the original push for this, and that's done too.

I definitely wasn't perfectly complete or consistent with how I did this, but I think things are significantly better organized than they were before. Ideally this provides a good reference for how to factor/refactor such code in other parts of the library. Definitely open to feedback on review.x

Resolves #43 