### PR TITLE
Separate log statistics

### DIFF
--- a/resources/config_templates/user/optimizer/class-recon.yaml
+++ b/resources/config_templates/user/optimizer/class-recon.yaml
@@ -11,7 +11,6 @@ optimizer: # torch.optim Class and parameters
 objective:
   _target_: retinal_rl.models.objective.Objective
   losses:
-    - _target_: retinal_rl.classification.loss.PercentCorrect
     - _target_: retinal_rl.classification.loss.ClassificationLoss
       target_circuits: # Circuit parameters to optimize with this optimizer.  We train the retina and the decoder exclusively to maximize reconstruction
         - retina
@@ -55,3 +54,5 @@ objective:
         - ${sparsity_weight}
         - ${sparsity_weight}
         - ${sparsity_weight}
+  logging_statistics:
+    - _target_: retinal_rl.classification.loss.PercentCorrect

--- a/retinal_rl/classification/loss.py
+++ b/retinal_rl/classification/loss.py
@@ -6,7 +6,7 @@ import torch
 from torch import Tensor, nn
 
 from retinal_rl.models.brain import Brain
-from retinal_rl.models.loss import BaseContext, Loss
+from retinal_rl.models.loss import BaseContext, LogStatistic, Loss
 
 
 class ClassificationContext(BaseContext):
@@ -61,17 +61,8 @@ class ClassificationLoss(Loss[ClassificationContext]):
         return self.loss_fn(predictions, classes)
 
 
-class PercentCorrect(Loss[ClassificationContext]):
+class PercentCorrect(LogStatistic[ClassificationContext]):
     """(Inverse) Loss for computing the percent correct classification."""
-
-    def __init__(
-        self,
-        target_circuits: List[str] = [],
-        weights: List[float] = [],
-        min_epoch: Optional[int] = None,
-        max_epoch: Optional[int] = None,
-    ):
-        super().__init__(target_circuits, weights, min_epoch, max_epoch)
 
     def compute_value(self, context: ClassificationContext) -> Tensor:
         """Compute the percent correct classification."""

--- a/retinal_rl/classification/loss.py
+++ b/retinal_rl/classification/loss.py
@@ -6,7 +6,7 @@ import torch
 from torch import Tensor, nn
 
 from retinal_rl.models.brain import Brain
-from retinal_rl.models.loss import BaseContext, LogStatistic, Loss
+from retinal_rl.models.loss import BaseContext, LoggingStatistic, Loss
 
 
 class ClassificationContext(BaseContext):
@@ -61,7 +61,7 @@ class ClassificationLoss(Loss[ClassificationContext]):
         return self.loss_fn(predictions, classes)
 
 
-class PercentCorrect(LogStatistic[ClassificationContext]):
+class PercentCorrect(LoggingStatistic[ClassificationContext]):
     """(Inverse) Loss for computing the percent correct classification."""
 
     def compute_value(self, context: ClassificationContext) -> Tensor:

--- a/retinal_rl/classification/loss.py
+++ b/retinal_rl/classification/loss.py
@@ -39,8 +39,8 @@ class ClassificationLoss(Loss[ClassificationContext]):
 
     def __init__(
         self,
-        target_circuits: List[str] = [],
-        weights: List[float] = [],
+        target_circuits: Optional[List[str]] = None,
+        weights: Optional[List[float]] = None,
         min_epoch: Optional[int] = None,
         max_epoch: Optional[int] = None,
     ):

--- a/retinal_rl/models/loss.py
+++ b/retinal_rl/models/loss.py
@@ -37,7 +37,7 @@ class BaseContext:
         self.epoch = epoch
 
 
-class LogStatistic(Generic[ContextT]):
+class LoggingStatistic(Generic[ContextT]):
     """Base class for statistics that should be logged."""
 
     def __call__(self, context: ContextT) -> Tensor:
@@ -54,7 +54,7 @@ class LogStatistic(Generic[ContextT]):
         return camel_to_snake(self.__class__.__name__)
 
 
-class Loss(LogStatistic[ContextT]):
+class Loss(LoggingStatistic[ContextT]):
     """Base class for losses that can be used to define a multiobjective optimization problem.
 
     Attributes

--- a/retinal_rl/models/loss.py
+++ b/retinal_rl/models/loss.py
@@ -38,8 +38,7 @@ class BaseContext:
 
 
 class LogStatistic(Generic[ContextT]):
-    """Base class for statistics that should be logged.
-    """
+    """Base class for statistics that should be logged."""
 
     def __call__(self, context: ContextT) -> Tensor:
         return self.compute_value(context)
@@ -60,7 +59,7 @@ class Loss(LogStatistic[ContextT]):
 
     Attributes
     ----------
-        target_circuits (List[str]): The target circuits for the loss.
+        target_circuits (List[str]): The target circuits for the loss. If '__all__', will target all circuits
         weights (List[float]): The weights for the loss.
         min_epoch (int): The minimum epoch to start training the loss.
         max_epoch (int): The maximum epoch to train the loss. Unbounded if < 0.

--- a/retinal_rl/models/loss.py
+++ b/retinal_rl/models/loss.py
@@ -68,12 +68,17 @@ class Loss(LoggingStatistic[ContextT]):
 
     def __init__(
         self,
-        target_circuits: List[str] = [],
-        weights: List[float] = [],
+        target_circuits: Optional[List[str]] = None,
+        weights: Optional[List[float]] = None,
         min_epoch: Optional[int] = None,
         max_epoch: Optional[int] = None,
     ):
         """Initialize the loss with a weight."""
+        if target_circuits is None:
+            target_circuits = []
+        if weights is None:
+            weights = [1]
+
         self.target_circuits = target_circuits
         self.weights = weights
         self.min_epoch = min_epoch
@@ -102,8 +107,8 @@ class ReconstructionLoss(Loss[ContextT]):
     def __init__(
         self,
         target_decoder: str,
-        target_circuits: List[str] = [],
-        weights: List[float] = [],
+        target_circuits: Optional[List[str]] = None,
+        weights: Optional[List[float]] = None,
         min_epoch: Optional[int] = None,
         max_epoch: Optional[int] = None,
     ):
@@ -136,8 +141,8 @@ class L1Sparsity(Loss[ContextT]):
     def __init__(
         self,
         target_response: str,
-        target_circuits: List[str] = [],
-        weights: List[float] = [],
+        target_circuits: Optional[List[str]] = None,
+        weights: Optional[List[float]] = None,
         min_epoch: Optional[int] = None,
         max_epoch: Optional[int] = None,
     ):
@@ -167,8 +172,8 @@ class KLDivergenceSparsity(Loss[ContextT]):
         self,
         target_response: str,
         target_sparsity: float = 0.05,
-        target_circuits: List[str] = [],
-        weights: List[float] = [],
+        target_circuits: Optional[List[str]] = None,
+        weights: Optional[List[float]] = None,
         min_epoch: Optional[int] = None,
         max_epoch: Optional[int] = None,
     ):

--- a/retinal_rl/models/objective.py
+++ b/retinal_rl/models/objective.py
@@ -7,15 +7,15 @@ import torch
 from torch.nn.parameter import Parameter
 
 from retinal_rl.models.brain import Brain
-from retinal_rl.models.loss import ContextT, Loss
+from retinal_rl.models.loss import ContextT, Loss, LogStatistic
 
 logger = logging.getLogger(__name__)
 
 
 class Objective(Generic[ContextT]):
-    def __init__(self, brain: Brain, losses: List[Loss[ContextT]]):
+    def __init__(self, brain: Brain, losses: List[LogStatistic[ContextT]]):
         self.device = next(brain.parameters()).device
-        self.losses: List[Loss[ContextT]] = losses
+        self.losses: List[LogStatistic[ContextT]] = losses
         self.brain: Brain = brain
 
         # Build a dictionary of weighted parameters for each loss
@@ -27,11 +27,15 @@ class Objective(Generic[ContextT]):
         retain_graph = True
 
         for i, loss in enumerate(self.losses):
-            # Compute losses
-            weights, params = self._weighted_params(loss)
             name = loss.key_name
             value = loss(context)
             loss_dict[name] = value.item()
+
+            if not isinstance(loss, Loss):
+                continue
+
+            # Compute losses
+            weights, params = self._weighted_params(loss)
             if not loss.is_training_epoch(context.epoch) or not params:
                 continue
 
@@ -59,7 +63,16 @@ class Objective(Generic[ContextT]):
     ) -> Tuple[List[float], List[Parameter]]:
         weights: List[float] = []
         params: List[Parameter] = []
-        for weight, circuit_name in zip(loss.weights, loss.target_circuits):
+        targets = loss.target_circuits
+        weights = loss.weights
+
+        if "__all__" in targets:
+            targets = self.brain.circuits.keys()
+            if len(weights) == 1:
+                weights = [weights[0] for _ in range(len(targets))]
+            assert len(weights) == len(targets)
+
+        for weight, circuit_name in zip(weights, targets):
             if circuit_name in self.brain.circuits:
                 params0 = list(self.brain.circuits[circuit_name].parameters())
                 weights += [weight] * len(params0)

--- a/retinal_rl/models/objective.py
+++ b/retinal_rl/models/objective.py
@@ -23,10 +23,12 @@ class Objective(Generic[ContextT]):
             logging_statistics = []
 
         for loss in losses:
-            assert isinstance(loss, Loss), "losses need to be subclass Loss"
+            assert isinstance(loss, Loss), "losses need to subclass Loss"
 
         for stat in logging_statistics:
-            assert isinstance(stat, LoggingStatistic), "logging_statistics need to be subclass LoggingStatistic"
+            assert isinstance(
+                stat, LoggingStatistic
+            ), "logging_statistics need to subclass LoggingStatistic"
 
         self.device = next(brain.parameters()).device
         self.losses = losses

--- a/tests/modules/conftest.py
+++ b/tests/modules/conftest.py
@@ -36,6 +36,7 @@ def config(experiment: str) -> DictConfig:
         OmegaConf.resolve(config)
         return config
 
+
 def cleanup(config: DictConfig):
     # Cleanup: remove temporary dir
     if os.path.exists(config.path.run_dir):
@@ -43,14 +44,15 @@ def cleanup(config: DictConfig):
 
 
 @pytest.fixture
-def classification_config()-> Generator[DictConfig, None, None]:
-    _config = config('classification')
+def classification_config() -> Generator[DictConfig, None, None]:
+    _config = config("classification")
     yield _config
     cleanup(_config)
 
+
 @pytest.fixture
 def rl_config() -> Generator[DictConfig, None, None]:
-    _config = config('gathering-apples')
+    _config = config("gathering-apples")
     yield _config
     cleanup(_config)
 

--- a/tests/modules/conftest.py
+++ b/tests/modules/conftest.py
@@ -9,7 +9,6 @@ import pytest
 from omegaconf import DictConfig, OmegaConf
 
 sys.path.append(".")
-from retinal_rl.models.brain import Brain
 from runner.util import search_conf
 
 OmegaConf.register_new_resolver("eval", eval)

--- a/tests/modules/conftest.py
+++ b/tests/modules/conftest.py
@@ -9,11 +9,13 @@ import pytest
 from omegaconf import DictConfig, OmegaConf
 
 sys.path.append(".")
+from retinal_rl.models.brain import Brain
 from runner.util import search_conf
 
 OmegaConf.register_new_resolver("eval", eval)
 
 
+# TODO: make this independent of whether templates are in the right place or not etc
 def config(experiment: str) -> DictConfig:
     with hydra.initialize(config_path="../../config/base", version_base=None):
         config = hydra.compose(

--- a/tests/modules/test_objective.py
+++ b/tests/modules/test_objective.py
@@ -1,5 +1,5 @@
-import torch
 import numpy as np
+import torch
 from hydra.utils import instantiate
 from omegaconf import DictConfig
 
@@ -7,33 +7,38 @@ from retinal_rl.classification.loss import ClassificationContext
 from retinal_rl.models.objective import Objective
 from runner.util import create_brain
 
+
 def test_objective(classification_config: DictConfig):
     brain = create_brain(classification_config.brain)
-    # brain.train()
-    objective: Objective[ClassificationContext] = instantiate(classification_config.optimizer.objective, brain=brain)
+    objective: Objective[ClassificationContext] = instantiate(
+        classification_config.optimizer.objective, brain=brain
+    )
     assert isinstance(objective, Objective)
 
     # create some random tensors to have sth for in / output
-    input = torch.zeros(1,*brain.sensors['vision'])
-    label = torch.ones(1,10)/10
+    input = torch.zeros(1, *brain.sensors["vision"])
+    label = torch.ones(1, 10) / 10
 
     # forward pass
-    stimuli = {'vision': input}
+    stimuli = {"vision": input}
     responses = brain(stimuli)
 
-    def grad_sum(model:torch.nn.Module):
-        return np.sum([0 if param.grad is None else np.sum(param.grad.numpy()) for param in model.parameters()])
+    def grad_sum(model: torch.nn.Module):
+        return np.sum(
+            [
+                0 if param.grad is None else np.sum(param.grad.numpy())
+                for param in model.parameters()
+            ]
+        )
 
     assert grad_sum(brain) == 0
 
     context = ClassificationContext(
-        sources=input,
-        inputs=input,
-        classes=label,
-        responses=responses,
-        epoch=1
+        sources=input, inputs=input, classes=label, responses=responses, epoch=1
     )
     loss_dict = objective.backward(context)
-    assert loss_dict['percent_correct'] == 0 or loss_dict['percent_correct'] == 1
+    assert loss_dict["percent_correct"] == 0 or loss_dict["percent_correct"] == 1
 
-    assert grad_sum(brain) != 0, "Objective should change the gradients, but it's still 0."
+    assert (
+        grad_sum(brain) != 0
+    ), "Objective should change the gradients, but it's still 0."

--- a/tests/modules/test_objective.py
+++ b/tests/modules/test_objective.py
@@ -1,20 +1,19 @@
 import numpy as np
+import pytest
 import torch
 from hydra.utils import instantiate
 from omegaconf import DictConfig
 
 from retinal_rl.classification.loss import ClassificationContext
+from retinal_rl.models.brain import Brain
 from retinal_rl.models.objective import Objective
 from runner.util import create_brain
 
 
-def test_objective(classification_config: DictConfig):
-    brain = create_brain(classification_config.brain)
-    objective: Objective[ClassificationContext] = instantiate(
-        classification_config.optimizer.objective, brain=brain
-    )
-    assert isinstance(objective, Objective)
-
+@pytest.mark.skip(reason="Just a helper function")
+def run_classification_objective(
+    brain: Brain, objective: Objective[ClassificationContext]
+):
     # create some random tensors to have sth for in / output
     input = torch.zeros(1, *brain.sensors["vision"])
     label = torch.ones(1, 10) / 10
@@ -23,22 +22,88 @@ def test_objective(classification_config: DictConfig):
     stimuli = {"vision": input}
     responses = brain(stimuli)
 
-    def grad_sum(model: torch.nn.Module):
-        return np.sum(
-            [
-                0 if param.grad is None else np.sum(param.grad.numpy())
-                for param in model.parameters()
-            ]
-        )
-
-    assert grad_sum(brain) == 0
-
     context = ClassificationContext(
         sources=input, inputs=input, classes=label, responses=responses, epoch=1
     )
-    loss_dict = objective.backward(context)
-    assert loss_dict["percent_correct"] == 0 or loss_dict["percent_correct"] == 1
+    return objective.backward(context)
 
+
+@pytest.mark.skip(reason="Just a helper function")
+def grad_sum(model: torch.nn.Module):
+    return np.sum(
+        [
+            0 if param.grad is None else np.sum(param.grad.numpy())
+            for param in model.parameters()
+        ]
+    )
+
+
+def test_classification_objective(classification_config: DictConfig):
+    brain = create_brain(classification_config.brain)
+    objective: Objective[ClassificationContext] = instantiate(
+        classification_config.optimizer.objective, brain=brain
+    )
+    assert isinstance(objective, Objective)
+
+    assert grad_sum(brain) == 0
+
+    loss_dict = run_classification_objective(brain, objective)
+
+    assert loss_dict["percent_correct"] == 0 or loss_dict["percent_correct"] == 1
+    assert (
+        grad_sum(brain) != 0
+    ), "Objective should change the gradients, but it's still 0."
+
+
+def test_objective_all():
+    brain_conf = DictConfig(
+        {
+            "name": "feedforward",
+            "sensors": {
+                "vision": [
+                    3,
+                    120,
+                    160,
+                ]
+            },
+            "connections": [["vision", "encoder"], ["encoder", "classifier"]],
+            "circuits": {
+                "encoder": {
+                    "_target_": "retinal_rl.models.circuits.convolutional.ConvolutionalEncoder",
+                    "num_layers": 3,
+                    "num_channels": [4, 8, 16],
+                    "kernel_size": 6,
+                    "stride": 2,
+                    "activation": "relu",
+                },
+                "classifier": {
+                    "_target_": "retinal_rl.models.circuits.fully_connected.FullyConnected",
+                    "output_shape": [10],
+                    "hidden_units": [128],
+                    "activation": "relu",
+                },
+            },
+        }
+    )
+
+    obj_conf = DictConfig(
+        {
+            "_target_": "retinal_rl.models.objective.Objective",
+            "losses": [
+                {
+                    "_target_": "retinal_rl.classification.loss.ClassificationLoss",
+                    "target_circuits": ["__all__"],
+                }
+            ],
+        }
+    )
+
+    brain = create_brain(brain_conf)
+
+    objective: Objective[ClassificationContext] = instantiate(obj_conf, brain=brain)
+
+    assert grad_sum(brain) == 0
+    run_classification_objective(brain, objective)
     assert (
         grad_sum(brain) != 0
     ), "Objective should change the gradients, but it's still 0."

--- a/tests/modules/test_objective.py
+++ b/tests/modules/test_objective.py
@@ -1,0 +1,39 @@
+import torch
+import numpy as np
+from hydra.utils import instantiate
+from omegaconf import DictConfig
+
+from retinal_rl.classification.loss import ClassificationContext
+from retinal_rl.models.objective import Objective
+from runner.util import create_brain
+
+def test_objective(classification_config: DictConfig):
+    brain = create_brain(classification_config.brain)
+    # brain.train()
+    objective: Objective[ClassificationContext] = instantiate(classification_config.optimizer.objective, brain=brain)
+    assert isinstance(objective, Objective)
+
+    # create some random tensors to have sth for in / output
+    input = torch.zeros(1,*brain.sensors['vision'])
+    label = torch.ones(1,10)/10
+
+    # forward pass
+    stimuli = {'vision': input}
+    responses = brain(stimuli)
+
+    def grad_sum(model:torch.nn.Module):
+        return np.sum([0 if param.grad is None else np.sum(param.grad.numpy()) for param in model.parameters()])
+
+    assert grad_sum(brain) == 0
+
+    context = ClassificationContext(
+        sources=input,
+        inputs=input,
+        classes=label,
+        responses=responses,
+        epoch=1
+    )
+    loss_dict = objective.backward(context)
+    assert loss_dict['percent_correct'] == 0 or loss_dict['percent_correct'] == 1
+
+    assert grad_sum(brain) != 0, "Objective should change the gradients, but it's still 0."

--- a/tests/modules/test_sample_factory.py
+++ b/tests/modules/test_sample_factory.py
@@ -1,6 +1,7 @@
 import sys
 
 from omegaconf import DictConfig
+import pytest
 from sample_factory.algo.utils.context import global_model_factory
 from sample_factory.algo.utils.make_env import make_env_func_batched
 from sample_factory.algo.utils.misc import ExperimentStatus
@@ -14,15 +15,15 @@ from retinal_rl.rl.sample_factory.models import SampleFactoryBrain
 from runner.frameworks.rl.sf_framework import SFFramework
 
 
-def test_init_framework(config: DictConfig, data_root):
-    framework = SFFramework(config, data_root)
-    cfg, runner = make_runner(framework.sf_cfg)
+def test_init_framework(rl_config: DictConfig, data_root: str):
+    framework = SFFramework(rl_config, data_root)
+    _, runner = make_runner(framework.sf_cfg)
     status = runner.init()
     assert status == ExperimentStatus.SUCCESS
 
 
-def test_actor_critic_brain(config: DictConfig, data_root):
-    sf_cfg = SFFramework.to_sf_cfg(config)
+def test_actor_critic_brain(rl_config: DictConfig, data_root: str):
+    sf_cfg = SFFramework.to_sf_cfg(rl_config)
     register_retinal_env(sf_cfg.env, data_root, False)
     global_model_factory().register_actor_critic_factory(SampleFactoryBrain)
     env = make_env_func_batched(

--- a/tests/modules/test_sample_factory.py
+++ b/tests/modules/test_sample_factory.py
@@ -1,7 +1,6 @@
 import sys
 
 from omegaconf import DictConfig
-import pytest
 from sample_factory.algo.utils.context import global_model_factory
 from sample_factory.algo.utils.make_env import make_env_func_batched
 from sample_factory.algo.utils.misc import ExperimentStatus


### PR DESCRIPTION
Adds a class for Logging Statistics instead of using a Loss for everything to make the interface a bit more expressive:

- Loss is an extension of LogStatistics
- added keyword '__all__' if a loss should just target the whole model
  - if so, the number of weights either has to match the number of circuits or be one (and then is repeated to match the number of circuits)
- added a test that runs the forward and backward pass once for the classification case and ensure that weights are being computed (nicer would be some proper test that correct weights are computed, maybe in the future)

Please double check the changes in the objectives _weighted_params function, as it's not sufficiently covered by the test :upside_down_face: 