### PR TITLE
Feature: add input warpscaling

### DIFF
--- a/retinal_rl/rl/sample_factory/arguments.py
+++ b/retinal_rl/rl/sample_factory/arguments.py
@@ -4,6 +4,7 @@ retina_rl library
 """
 
 from typing import Optional
+
 from sample_factory.utils.utils import str2bool
 from sf_examples.vizdoom.doom.doom_params import (
     add_doom_env_args,

--- a/retinal_rl/rl/sample_factory/environment.py
+++ b/retinal_rl/rl/sample_factory/environment.py
@@ -45,7 +45,7 @@ class WarpResizeWrapper(gym.core.Wrapper):
     """Resize observation frames to specified (w,h) and convert to grayscale."""
 
     def __init__(self, env, h: int, w: int, warp_exp: float = 2.0):
-        super(WarpResizeWrapper, self).__init__(env)
+        super().__init__(env)
 
         self.w = w
         self.h = h
@@ -91,11 +91,11 @@ class WarpResizeWrapper(gym.core.Wrapper):
         col_even = out_shape[1] % 2
         row_idx = np.round(
             (np.arange(0, out_shape_half[0]) / (out_shape_half[0] - 1)) ** exp
-            * (center[0] - (1+row_even))
+            * (center[0] - (1 + row_even))
         ).astype(int)  # Generate indices for rows and columns
         col_idx = np.round(
             (np.arange(0, out_shape_half[1]) / (out_shape_half[1] - 1)) ** exp
-            * (center[1] - (1+col_even))
+            * (center[1] - (1 + col_even))
         ).astype(int)
 
         # ensure difference is at least 1 pixel
@@ -104,12 +104,12 @@ class WarpResizeWrapper(gym.core.Wrapper):
         row_idx[row_idx < row_inc] = row_inc[row_idx < row_inc]
         col_idx[col_idx < col_inc] = col_inc[col_idx < col_inc]
 
-        h = center[0] - row_idx[::-1] - 1 -row_even
-        w = center[1] - col_idx[::-1] - 1 -col_even
+        h = center[0] - row_idx[::-1] - 1 - row_even
+        w = center[1] - col_idx[::-1] - 1 - col_even
         if row_even:
-            h = np.hstack([h, center[0]-1])
+            h = np.hstack([h, center[0] - 1])
         if col_even:
-            w = np.hstack([w, center[1]-1])
+            w = np.hstack([w, center[1] - 1])
         h = np.hstack([h, row_idx + center[0]])
         w = np.hstack([w, col_idx + center[1]])
         if channel_last:
@@ -122,8 +122,9 @@ class WarpResizeWrapper(gym.core.Wrapper):
         if obs is None:
             return obs
 
-        obs = self.center_warp_image(obs, out_shape=(self.h, self.w), exp=self.warp_exp)
-        return obs
+        return self.center_warp_image(
+            obs, out_shape=(self.h, self.w), exp=self.warp_exp
+        )
 
     def _observation(self, obs):
         if isinstance(obs, dict):
@@ -131,8 +132,7 @@ class WarpResizeWrapper(gym.core.Wrapper):
             for key, value in obs.items():
                 new_obs[key] = self._convert_obs(value)
             return new_obs
-        else:
-            return self._convert_obs(obs)
+        return self._convert_obs(obs)
 
     def reset(self, **kwargs):
         obs, info = self.env.reset(**kwargs)

--- a/runner/frameworks/rl/sf_framework.py
+++ b/runner/frameworks/rl/sf_framework.py
@@ -166,9 +166,7 @@ class SFFramework(TrainingFramework):
         # Using this function is necessary to make sure that the parameters are not overwritten when sample_factory loads a checkpoint
 
         if hasattr(cfg.dataset, "warp_exp") and cfg.dataset.warp_exp is not None:
-            SFFramework._set_cfg_cli_argument(
-                sf_cfg, "warp_exp", cfg.dataset.warp_exp
-            )
+            SFFramework._set_cfg_cli_argument(sf_cfg, "warp_exp", cfg.dataset.warp_exp)
             SFFramework._set_cfg_cli_argument(
                 sf_cfg, "warp_h", cfg.dataset.vision_height
             )
@@ -176,7 +174,9 @@ class SFFramework(TrainingFramework):
                 sf_cfg, "warp_w", cfg.dataset.vision_width
             )
         else:
-            SFFramework._set_cfg_cli_argument(sf_cfg, "res_h", cfg.dataset.vision_height)
+            SFFramework._set_cfg_cli_argument(
+                sf_cfg, "res_h", cfg.dataset.vision_height
+            )
             SFFramework._set_cfg_cli_argument(sf_cfg, "res_w", cfg.dataset.vision_width)
         SFFramework._set_cfg_cli_argument(sf_cfg, "env", cfg.dataset.env_name)
         SFFramework._set_cfg_cli_argument(


### PR DESCRIPTION
Adds the possibility to 'warp' the input and by that get a 'foveated' vision.
It does so by sampling at full resolution in the center and then skipping more and more rows/lines to the outside, depending on
- warp_exp
and the output size after warping defined through
- warp_h
- warp_w

Open TODOs:
- [ ] better hydra like setting of the parameters (currently can be set only directly via the samplefactory parameter) - perhaps in general a good idea to discuss how to deal with that
- [ ] documentation