### PR TITLE
fix: need to check in forward if brain has no rnn_state in connectome

### DIFF
--- a/retinal_rl/rl/sample_factory/models.py
+++ b/retinal_rl/rl/sample_factory/models.py
@@ -110,7 +110,9 @@ class SampleFactoryBrain(ActorCritic, ActorCriticProtocol):
 
         # pipe rnn states through result dict for sample factory
         # TODO: Support for multiple RNN nodes?
-        rnn_node = [node for node in self.brain.connectome.successors("rnn_state")]
+        rnn_node = []
+        if "rnn_state" in self.brain.connectome.nodes:
+            rnn_node = [node for node in self.brain.connectome.successors("rnn_state")]
         if len(rnn_node) == 1:
             core_out = responses[rnn_node[0]][rnn_state_index]
             result["new_rnn_states"] = core_out


### PR DESCRIPTION
the latest fix included a bug when no rnn was part of the brain. fixed with this PR.