### PR TITLE
fix: ensure container should always run, but not necessarily rebuild

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,10 +32,11 @@ jobs:
 
   ensure_container: # main cache should provide the container if def file not changed
     name: Rebuild container
+    needs: check_def_changed
     if: always()
     uses: ./.github/workflows/update_cache.yml
     with:
-      build: true
+      build: ${{ needs.check_def_changed.outputs.changed == 'true' }}
 
   checks:
     name: Code Checks


### PR DESCRIPTION
I need this PR for dev already to see if the pull workflow now works