### PR TITLE
Improve CI script usability

### DIFF
--- a/tests/ci/build_scenario.sh
+++ b/tests/ci/build_scenario.sh
@@ -10,4 +10,10 @@
 #   (run from top level directory!)
 #===============================================================================
 
-singularity exec "$1" python -m doom_creator.compile_scenario gathering apples
+if [ "$1" == "" ]; then
+    SINGULARITY_PREFIX=""
+else
+    SINGULARITY_PREFIX="singularity exec $1"
+fi
+
+$SINGULARITY_PREFIX python -m doom_creator.compile_scenario gathering apples

--- a/tests/ci/lint.sh
+++ b/tests/ci/lint.sh
@@ -21,9 +21,14 @@
 # - Container must have ruff installed
 #===============================================================================
 
-# Store the container path
-CONTAINER="$1"
-shift
+
+# Helper to consume first arg as container if it doesn't start with '-'
+if [ $# -gt 0 ] && [[ $1 != -* ]]; then
+    SINGULARITY_PREFIX="singularity exec $1"
+    shift
+else
+    SINGULARITY_PREFIX=""
+fi
 
 # Check or fix
 check="--check"
@@ -43,9 +48,9 @@ fi
 
 if [ -n "$changed_files" ]; then
     # Format
-    singularity exec "$CONTAINER" ruff format $changed_files $check
+    $SINGULARITY_PREFIX ruff format $changed_files $check
     # Run ruff on changed files with any remaining arguments
-    singularity exec "$CONTAINER" ruff check $changed_files "$@"
+    $SINGULARITY_PREFIX ruff check $changed_files "$@"
 else
     echo "No .py files changed"
 fi

--- a/tests/ci/scan_configs.sh
+++ b/tests/ci/scan_configs.sh
@@ -15,8 +15,13 @@
 #   - YAML configuration files in correct directory
 #===============================================================================
 
+if [ "$1" == "" ]; then
+    SINGULARITY_PREFIX=""
+else
+    SINGULARITY_PREFIX="singularity exec $1"
+fi
+
 for file in config/user/experiment/*.yaml; do
     experiment=$(basename "$file" .yaml)
-    singularity exec "$1" \
-    python main.py +experiment="$experiment" command=scan system.device=cpu
+    $SINGULARITY_PREFIX python main.py +experiment="$experiment" command=scan system.device=cpu
 done


### PR DESCRIPTION
Before, the ci scripts could only be used with passing a singularity container.
However, if you are working within an singularity container or some other envirnoment where you have the tools (ruff etc) installed, it is annoying to always add this.
This makes passing the singularity container optional:
`./tests/ci/lint.sh --fix` now works as well as `./tests/ci/lint.sh CONTAINER.sif --fix`