### PR TITLE
fix: add potential local wandb to ignore list for linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ lint.ignore = [
 [tool.ruff.format]
 docstring-code-format = true
 
+[tool.ruff.lint.isort]
+known-third-party = ["wandb"]
+
 [tool.setuptools]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
A tiny change in the pyproject.toml that ensures that when running the code linting and checks, 'wandb' is not considered a local library.
The problem happens when a local directory with the name 'wandb' is present (possible depending on logging setup  - but in gitignore anyway!).