### PR TITLE
'gabor10' scenarios, log pickup statistics, Pickup reward shaping

### DIFF
--- a/retinal_rl/rl/sample_factory/environment.py
+++ b/retinal_rl/rl/sample_factory/environment.py
@@ -92,16 +92,60 @@ class SatietyInput(gym.Wrapper):
         return obs_dict, rew, terminated, truncated, info
 
 
+class PickupTrackingWrapper(gym.Wrapper):
+    def __init__(self, env):
+        super().__init__(env)
+        # TODO: make object values configurable / get from environment
+        self.object_values = np.array([-25, -20, -15, -10, -5, 10, 20, 30, 40, 50])
+        self.pickup_counts = {str(object_value): 0 for object_value in self.object_values}
+        self.last_health = None
+
+    def reset(self, **kwargs):
+        obs, info = self.env.reset(**kwargs)
+        for object_value in self.pickup_counts:
+            self.pickup_counts[object_value] = 0
+        self.last_health = info.get("USER17")
+        return obs, info
+
+    def step(self, action):
+        obs, rew, terminated, truncated, info = self.env.step(action)
+
+        unbound_health = info.get("USER17")
+        diff = unbound_health - self.last_health if self.last_health is not None else 0
+        self.last_health = unbound_health
+        # Accept differences up to one (eg health decreases by 1 periodically, which can coincide with the pickup of an object)
+        picked_up_object = np.abs(diff - self.object_values) <= 1
+        if np.sum(picked_up_object) == 1:
+            for object_value in self.object_values[picked_up_object]:
+                self.pickup_counts[str(object_value)] += 1
+
+        if picked_up_object.sum() > 1 or (
+            picked_up_object.sum() == 0 and diff not in [0, -1]
+        ):
+            print(
+                f"Warning: Detected pickup of multiple objects or an object with an unexpected value. Diff: {diff}, Picked up objects: {self.object_values[picked_up_object]}"
+            )
+            # TODO: proper logging
+
+        if "episode_extra_stats" not in info:
+            info["episode_extra_stats"] = dict()
+        info["episode_extra_stats"]["pickup_counts"] = (
+            self.pickup_counts.copy()
+        )  # Add a copy of the pickup counts to the info dict
+
+        return obs, rew, terminated, truncated, info
+
+
 ### Retinal Environments ###
 
 
 def retinal_doomspec(
     scene_name: str, cfg_path: str, sat_in: bool, allow_backwards: bool
 ):
-    ewraps = []
+    ewraps = [(PickupTrackingWrapper, {})]
 
     if sat_in:
-        ewraps = [(SatietyInput, {})]
+        ewraps.append(SatietyInput, {})
 
     action_space = (
         doom_action_space_basic()

--- a/retinal_rl/rl/sample_factory/environment.py
+++ b/retinal_rl/rl/sample_factory/environment.py
@@ -102,6 +102,7 @@ class PickupTrackingWrapper(gym.Wrapper):
 
     def reset(self, **kwargs):
         obs, info = self.env.reset(**kwargs)
+        self.pickup_counts = {str(object_value): 0 for object_value in self.object_values}
         return obs, info
 
     def step(self, action):

--- a/retinal_rl/rl/sample_factory/environment.py
+++ b/retinal_rl/rl/sample_factory/environment.py
@@ -134,7 +134,6 @@ class PickupTrackingWrapper(gym.Wrapper):
         return obs, rew, terminated, truncated, info
 
 
-
 class PickupRewardShaping(gym.Wrapper):
     """Based on SampleFactories GatheringRewardShaping wrapper."""
 
@@ -142,17 +141,22 @@ class PickupRewardShaping(gym.Wrapper):
         super().__init__(env)
         self._prev_health = None
         self.additive = additive
+        self.metabolic_cost = 1
+        self.metabolic_delay = 2
 
     def _reward_shaping(self, info, done):
         if info is None or done:
             return 0.0
 
         curr_health = info.get("HEALTH", 0.0)
+        living_penalty = info.get("num_frames") * self.metabolic_cost / self.metabolic_delay
         reward = 0.0
 
         if self._prev_health is not None:
             delta = curr_health - self._prev_health
-            reward = delta / 100 # max health is 100, so this should normalize it well
+            # remove 'living penalty' from reward
+            # max health is 100, so this should normalize it well
+            reward = 0 if delta == -living_penalty else delta / 100
 
         self._prev_health = curr_health
         return reward
@@ -165,14 +169,19 @@ class PickupRewardShaping(gym.Wrapper):
         observation, reward, terminated, truncated, info = self.env.step(action)
         done = terminated | truncated
         pickup_reward = self._reward_shaping(info, done)
-        reward = reward + pickup_reward if self.additive else pickup_reward 
+        reward = reward + pickup_reward if self.additive else pickup_reward
         return observation, reward, terminated, truncated, info
+
 
 ### Retinal Environments ###
 
 
 def retinal_doomspec(
-    scene_name: str, cfg_path: str, sat_in: bool, allow_backwards: bool, pickup_reward: bool = True
+    scene_name: str,
+    cfg_path: str,
+    sat_in: bool,
+    allow_backwards: bool,
+    pickup_reward: bool = True,
 ):
     ewraps = [(PickupTrackingWrapper, {})]
 

--- a/retinal_rl/rl/sample_factory/environment.py
+++ b/retinal_rl/rl/sample_factory/environment.py
@@ -96,7 +96,7 @@ class SatietyInput(gym.Wrapper):
 class PickupTrackingWrapper(gym.Wrapper):
     def __init__(self, env):
         super().__init__(env)
-        # TODO: make object values configurable / get from environment
+        # TODO: make object values configurable / get from environment. One way might be to auto-discover them on the go.
         self.object_values = np.array([-25, -20, -15, -10, -5, 10, 20, 30, 40, 50])
         self.pickup_counts = {str(obj_val): 0 for obj_val in self.object_values}
         self.last_health = None
@@ -110,7 +110,9 @@ class PickupTrackingWrapper(gym.Wrapper):
     def step(self, action):
         obs, rew, terminated, truncated, info = self.env.step(action)
 
-        unbound_health = info.get("USER17")
+        unbound_health = info.get(
+            "USER17"
+        )  # USER17 is the unbound health variable exposed through vizdoom.cfg in doom_creator
         diff = unbound_health - self.last_health if self.last_health is not None else 0
         self.last_health = unbound_health
         # Accept differences up to one (eg health decreases by 1 periodically, which can coincide with the pickup of an object)
@@ -119,15 +121,12 @@ class PickupTrackingWrapper(gym.Wrapper):
             for object_value in self.object_values[picked_up_object]:
                 self.pickup_counts[str(object_value)] += 1
 
-
         done = terminated | truncated
         unknown_diff = picked_up_object.sum() > 1 or (
             picked_up_object.sum() == 0 and diff not in [0, -1]
         )
         if not done and unknown_diff:
-            log.warning(
-                f"Unexpected unbound health difference: {diff}."
-            )
+            log.warning(f"Unexpected unbound health difference: {diff}.")
 
         if "episode_extra_stats" not in info:
             info["episode_extra_stats"] = dict()
@@ -153,7 +152,9 @@ class PickupRewardShaping(gym.Wrapper):
             return 0.0
 
         curr_health = info.get("HEALTH", 0.0)
-        living_penalty = info.get("num_frames") * self.metabolic_cost / self.metabolic_delay
+        living_penalty = (
+            info.get("num_frames") * self.metabolic_cost / self.metabolic_delay
+        )
         reward = 0.0
 
         if self._prev_health is not None:

--- a/retinal_rl/rl/sample_factory/environment.py
+++ b/retinal_rl/rl/sample_factory/environment.py
@@ -102,9 +102,6 @@ class PickupTrackingWrapper(gym.Wrapper):
 
     def reset(self, **kwargs):
         obs, info = self.env.reset(**kwargs)
-        for object_value in self.pickup_counts:
-            self.pickup_counts[object_value] = 0
-        self.last_health = info.get("USER17")
         return obs, info
 
     def step(self, action):

--- a/retinal_rl/rl/sample_factory/environment.py
+++ b/retinal_rl/rl/sample_factory/environment.py
@@ -97,12 +97,12 @@ class PickupTrackingWrapper(gym.Wrapper):
         super().__init__(env)
         # TODO: make object values configurable / get from environment
         self.object_values = np.array([-25, -20, -15, -10, -5, 10, 20, 30, 40, 50])
-        self.pickup_counts = {str(object_value): 0 for object_value in self.object_values}
+        self.pickup_counts = {str(obj_val): 0 for obj_val in self.object_values}
         self.last_health = None
 
     def reset(self, **kwargs):
         obs, info = self.env.reset(**kwargs)
-        self.pickup_counts = {str(object_value): 0 for object_value in self.object_values}
+        self.pickup_counts = {str(_val): 0 for _val in self.object_values}
         return obs, info
 
     def step(self, action):

--- a/retinal_rl/rl/sample_factory/environment.py
+++ b/retinal_rl/rl/sample_factory/environment.py
@@ -134,16 +134,51 @@ class PickupTrackingWrapper(gym.Wrapper):
         return obs, rew, terminated, truncated, info
 
 
+
+class PickupRewardShaping(gym.Wrapper):
+    """Based on SampleFactories GatheringRewardShaping wrapper."""
+
+    def __init__(self, env):
+        super().__init__(env)
+        self._prev_health = None
+
+    def _reward_shaping(self, info, done):
+        if info is None or done:
+            return 0.0
+
+        curr_health = info.get("HEALTH", 0.0)
+        reward = 0.0
+
+        if self._prev_health is not None:
+            delta = curr_health - self._prev_health
+            reward = delta / 100 # max health is 100, so this should normalize it well
+
+        self._prev_health = curr_health
+        return reward
+
+    def reset(self, **kwargs):
+        self._prev_health = None
+        return self.env.reset(**kwargs)
+
+    def step(self, action):
+        observation, reward, terminated, truncated, info = self.env.step(action)
+        done = terminated | truncated
+        reward += self._reward_shaping(info, done)
+        return observation, reward, terminated, truncated, info
+
 ### Retinal Environments ###
 
 
 def retinal_doomspec(
-    scene_name: str, cfg_path: str, sat_in: bool, allow_backwards: bool
+    scene_name: str, cfg_path: str, sat_in: bool, allow_backwards: bool, pickup_reward: bool = True
 ):
     ewraps = [(PickupTrackingWrapper, {})]
 
     if sat_in:
-        ewraps.append(SatietyInput, {})
+        ewraps.append((SatietyInput, {}))
+
+    if pickup_reward:
+        ewraps.append((PickupRewardShaping, {}))
 
     action_space = (
         doom_action_space_basic()

--- a/retinal_rl/rl/sample_factory/environment.py
+++ b/retinal_rl/rl/sample_factory/environment.py
@@ -138,9 +138,10 @@ class PickupTrackingWrapper(gym.Wrapper):
 class PickupRewardShaping(gym.Wrapper):
     """Based on SampleFactories GatheringRewardShaping wrapper."""
 
-    def __init__(self, env):
+    def __init__(self, env, additive: bool = True):
         super().__init__(env)
         self._prev_health = None
+        self.additive = additive
 
     def _reward_shaping(self, info, done):
         if info is None or done:
@@ -163,7 +164,8 @@ class PickupRewardShaping(gym.Wrapper):
     def step(self, action):
         observation, reward, terminated, truncated, info = self.env.step(action)
         done = terminated | truncated
-        reward += self._reward_shaping(info, done)
+        pickup_reward = self._reward_shaping(info, done)
+        reward = reward + pickup_reward if self.additive else pickup_reward 
         return observation, reward, terminated, truncated, info
 
 ### Retinal Environments ###
@@ -178,7 +180,7 @@ def retinal_doomspec(
         ewraps.append((SatietyInput, {}))
 
     if pickup_reward:
-        ewraps.append((PickupRewardShaping, {}))
+        ewraps.append((PickupRewardShaping, {"additive": False}))
 
     action_space = (
         doom_action_space_basic()

--- a/retinal_rl/rl/sample_factory/environment.py
+++ b/retinal_rl/rl/sample_factory/environment.py
@@ -8,6 +8,7 @@ import numpy as np
 # import gym
 from gymnasium.spaces import Discrete
 from sample_factory.envs.env_utils import register_env
+from sample_factory.utils.utils import log
 from sf_examples.vizdoom.doom.action_space import (
     doom_action_space_basic,
     key_to_action_basic,
@@ -103,6 +104,7 @@ class PickupTrackingWrapper(gym.Wrapper):
     def reset(self, **kwargs):
         obs, info = self.env.reset(**kwargs)
         self.pickup_counts = {str(_val): 0 for _val in self.object_values}
+        self.last_health = None
         return obs, info
 
     def step(self, action):
@@ -117,13 +119,15 @@ class PickupTrackingWrapper(gym.Wrapper):
             for object_value in self.object_values[picked_up_object]:
                 self.pickup_counts[str(object_value)] += 1
 
-        if picked_up_object.sum() > 1 or (
+
+        done = terminated | truncated
+        unknown_diff = picked_up_object.sum() > 1 or (
             picked_up_object.sum() == 0 and diff not in [0, -1]
-        ):
-            print(
-                f"Warning: Detected pickup of multiple objects or an object with an unexpected value. Diff: {diff}, Picked up objects: {self.object_values[picked_up_object]}"
+        )
+        if not done and unknown_diff:
+            log.warning(
+                f"Unexpected unbound health difference: {diff}."
             )
-            # TODO: proper logging
 
         if "episode_extra_stats" not in info:
             info["episode_extra_stats"] = dict()

--- a/retinal_rl/rl/sample_factory/observer.py
+++ b/retinal_rl/rl/sample_factory/observer.py
@@ -3,13 +3,14 @@ from pathlib import Path
 
 import torch
 from hydra.utils import instantiate
-from sample_factory.algo.runners.runner import AlgoObserver, Runner
-from sample_factory.utils.typing import Config
+from sample_factory.algo.runners.runner import AlgoObserver, Runner, SummaryWriter
+from sample_factory.utils.typing import Config, PolicyID
 from sample_factory.utils.utils import log
 
 from retinal_rl.models.objective import Objective
 from retinal_rl.rl.analyze import AnalysesCfg, analyze
 from retinal_rl.rl.loss import RLContext
+from retinal_rl.rl.sample_factory.retinal_stats_handler import retinal_stats_handler
 from retinal_rl.rl.sample_factory.util import load_brain_from_checkpoint
 
 multiprocessing.set_start_method(
@@ -80,7 +81,6 @@ class RetinalAlgoObserver(AlgoObserver):
         self, runner: Runner, training_iteration_since_resume: int
     ) -> None:  # TODO: deprecated and will be refactored anyway
         """Called after each training step."""
-        # TODO: Check and refactor
         total_env_steps = sum(runner.env_steps.values())
 
         if total_env_steps >= self.next_analysis_step:
@@ -94,3 +94,28 @@ class RetinalAlgoObserver(AlgoObserver):
                 self.cur_freq, self.end_freq
             )
             self.cur_freq = self.cur_freq * 2
+
+    # Use extra summaries for now TODO: unify with classification logging
+    def extra_summaries(
+        self,
+        runner: Runner,
+        policy_id: PolicyID,
+        summary_writer: SummaryWriter,
+        env_steps: int,
+    ) -> None:
+        # report pickup frequencies
+        if retinal_stats_handler.pickups:
+            summed_pickups = {
+                stat_key: sum(stat_values)
+                for stat_key, stat_values in retinal_stats_handler.pickups.items()
+            }
+            total_pickups = max(
+                sum(summed_pickups.values()), 1
+            )  # ensure no division by zero
+
+            for stat_key, stat_value in summed_pickups.items():
+                summary_writer.add_scalar(
+                    f"pickups/{stat_key}", stat_value / total_pickups, env_steps
+                )
+                # Clear the stats after logging
+                retinal_stats_handler.pickups[stat_key] = 0

--- a/retinal_rl/rl/sample_factory/observer.py
+++ b/retinal_rl/rl/sample_factory/observer.py
@@ -105,13 +105,19 @@ class RetinalAlgoObserver(AlgoObserver):
     ) -> None:
         # report pickup frequencies
         if retinal_stats_handler.pickups:
+            pickups = retinal_stats_handler.pickups
+            
+            # Reset Pickups dict
+            retinal_stats_handler.pickups = dict()
+
             total_pickups = max(
-                sum(retinal_stats_handler.pickups.values()), 1
+                sum(pickups.values()), 1
             )  # ensure no division by zero
 
-            for object_value, num_pickups in retinal_stats_handler.pickups.items():
+            for object_value, num_pickups in pickups.items():
                 summary_writer.add_scalar(
-                    f"pickups/{object_value}", num_pickups / total_pickups, env_steps
+                    f"pickups/{object_value}", num_pickups/total_pickups, env_steps
                 )
-                # Clear the stats after logging
-                retinal_stats_handler.pickups[object_value] = 0
+                summary_writer.add_scalar(
+                    f"pickups/abs_{object_value}", num_pickups, env_steps
+                )

--- a/retinal_rl/rl/sample_factory/observer.py
+++ b/retinal_rl/rl/sample_factory/observer.py
@@ -105,17 +105,13 @@ class RetinalAlgoObserver(AlgoObserver):
     ) -> None:
         # report pickup frequencies
         if retinal_stats_handler.pickups:
-            summed_pickups = {
-                stat_key: sum(stat_values)
-                for stat_key, stat_values in retinal_stats_handler.pickups.items()
-            }
             total_pickups = max(
-                sum(summed_pickups.values()), 1
+                sum(retinal_stats_handler.pickups.values()), 1
             )  # ensure no division by zero
 
-            for stat_key, stat_value in summed_pickups.items():
+            for object_value, num_pickups in retinal_stats_handler.pickups.items():
                 summary_writer.add_scalar(
-                    f"pickups/{stat_key}", stat_value / total_pickups, env_steps
+                    f"pickups/{object_value}", num_pickups / total_pickups, env_steps
                 )
                 # Clear the stats after logging
-                retinal_stats_handler.pickups[stat_key] = 0
+                retinal_stats_handler.pickups[object_value] = 0

--- a/retinal_rl/rl/sample_factory/observer.py
+++ b/retinal_rl/rl/sample_factory/observer.py
@@ -106,17 +106,15 @@ class RetinalAlgoObserver(AlgoObserver):
         # report pickup frequencies
         if retinal_stats_handler.pickups:
             pickups = retinal_stats_handler.pickups
-            
+
             # Reset Pickups dict
             retinal_stats_handler.pickups = dict()
 
-            total_pickups = max(
-                sum(pickups.values()), 1
-            )  # ensure no division by zero
+            total_pickups = max(sum(pickups.values()), 1)  # ensure no division by zero
 
             for object_value, num_pickups in pickups.items():
                 summary_writer.add_scalar(
-                    f"pickups/{object_value}", num_pickups/total_pickups, env_steps
+                    f"pickups/{object_value}", num_pickups / total_pickups, env_steps
                 )
                 summary_writer.add_scalar(
                     f"pickups/abs_{object_value}", num_pickups, env_steps

--- a/retinal_rl/rl/sample_factory/retinal_stats_handler.py
+++ b/retinal_rl/rl/sample_factory/retinal_stats_handler.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+from sample_factory.algo.runners.runner import Runner
+from sample_factory.algo.utils.misc import EPISODIC
+from sample_factory.utils.typing import PolicyID
+from sample_factory.utils.utils import static_vars
+
+
+@static_vars(pickups=dict())
+def retinal_stats_handler(_runner: Runner, msg: Dict, _policy_id: PolicyID) -> None:
+    cur_episode_pickups = (
+        msg[EPISODIC].get("episode_extra_stats", {}).get("pickup_counts", {})
+    )
+    for stat_key, stat_value in cur_episode_pickups.items():
+        if stat_key not in retinal_stats_handler.pickups:
+            retinal_stats_handler.pickups[stat_key] = 0
+        if stat_value is not None:  # Only append if the stat value is not None
+            retinal_stats_handler.pickups[stat_key] += stat_value

--- a/runner/frameworks/rl/sf_framework.py
+++ b/runner/frameworks/rl/sf_framework.py
@@ -40,6 +40,7 @@ from retinal_rl.rl.sample_factory.environment import register_retinal_env
 from retinal_rl.rl.sample_factory.learner import RetinalLearner
 from retinal_rl.rl.sample_factory.models import SampleFactoryBrain
 from retinal_rl.rl.sample_factory.observer import RetinalAlgoObserver
+from retinal_rl.rl.sample_factory.retinal_stats_handler import retinal_stats_handler
 from runner.frameworks.classification.initialize import initialize
 from runner.frameworks.framework_interface import TrainingFramework
 from runner.util import create_brain
@@ -121,6 +122,7 @@ class SFFramework(TrainingFramework):
             cfg, runner = make_runner(self.sf_cfg)
             # if cfg.online_analysis:
             runner.register_observer(RetinalAlgoObserver(self.sf_cfg))
+            runner.register_episodic_stats_handler(retinal_stats_handler)
 
             status = runner.init()
 


### PR DESCRIPTION
This is a bit of a combination of several features:

## gabors -> gabor10
- added 2 gabor orientations so none is used for multiple object values
- made sure these images get 'doomified'

## log pickup statistics
- the 'PickupTrackingWrapper' adds the functionality that through the training, the picking up of objects gets tracked and reported to Tensorboard / wandb

## Change reward structure via Pickup "Reward shaper"
- probably the most debatable change. Instead of adjust the doom envs, I change the reward here in code:
  - the returned reward by the doom env is the current health
  - the pickup reward shaper instead returns the difference in health, hence the value of the picked up object