### PR TITLE
fix: update samplefactory commit, avoid env_info none

### DIFF
--- a/resources/retinal-rl.def
+++ b/resources/retinal-rl.def
@@ -75,7 +75,7 @@ From: ubuntu:22.04
     torchinfo==1.8.0 \
     num2words==0.5.13 \
     omgifol==0.5.1 \
-    git+https://github.com/fabioseel/sample-factory.git@97a8127fb7afd38a0d8513897aa52dfb7069c0cf \
+    git+https://github.com/fabioseel/sample-factory.git@41a0c893c29d9fa9c35e43ad2239156b006d3df2 \
     dpcpp-cpp-rt==2024.2.1 \
     seaborn==0.13.2 \
     hydra-core==1.3.2 \


### PR DESCRIPTION
This should fix one of the most common remaining issues why rl trainings abort.
I do not know the specific circumstances when it happens, but sometimes the Doom environment seems to return "None" as env_info (eg after a env.reset).
The new referenced commit should get rid of that.